### PR TITLE
fix sddm README image paths

### DIFF
--- a/sddm/README.md
+++ b/sddm/README.md
@@ -17,5 +17,5 @@ GNU GPL v3
 
 ## preview
 
-![light](images/Preview-Light.jpg)
-![dark](images/Preview-Dark.jpg)
+![light](images/Preview-Light.jpeg)
+![dark](images/Preview-Dark.jpeg)


### PR DESCRIPTION
## How to recreate the issue:
- Go to [vinceliuice/MacTahoe-kde/sddm/README.md](https://github.com/vinceliuice/MacTahoe-kde/tree/main/sddm/README.md), and press the image links.

### To see my fix: 
- [c6rg0/Mactahoe-kde/sddm/README.md](https://github.com/c6rg0/MacTahoe-kde/tree/main/sddm).

